### PR TITLE
Add direct story-to-Google-Drive workflow for repo owner

### DIFF
--- a/.github/workflows/add-story-to-drive.yml
+++ b/.github/workflows/add-story-to-drive.yml
@@ -1,0 +1,72 @@
+name: Add Story to Google Drive
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: 'Story title'
+        required: true
+        type: string
+      about:
+        description: 'Who is this story about? (comma-separated names)'
+        required: true
+        type: string
+      story:
+        description: 'The story content (use \n for line breaks)'
+        required: true
+        type: string
+      author:
+        description: 'Author name'
+        required: false
+        default: 'Patrick Ruff'
+        type: string
+
+jobs:
+  add-story:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Add story to Google Drive
+        id: add_story
+        env:
+          GOOGLE_DRIVE_CREDENTIALS: ${{ secrets.GOOGLE_DRIVE_CREDENTIALS }}
+        run: |
+          # Convert \n to actual newlines in story content
+          STORY_CONTENT=$(echo "${{ github.event.inputs.story }}" | sed 's/\\n/\n/g')
+
+          python add_story_to_drive.py \
+            --title "${{ github.event.inputs.title }}" \
+            --about "${{ github.event.inputs.about }}" \
+            --author "${{ github.event.inputs.author }}" \
+            --story "$STORY_CONTENT"
+
+      - name: Summary
+        run: |
+          echo "## Story Added to Google Drive" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Title** | ${{ github.event.inputs.title }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **About** | ${{ github.event.inputs.about }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Author** | ${{ github.event.inputs.author }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The story has been uploaded to Google Drive. To make it searchable:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "1. **Wait for automatic sync** (runs every 6 hours)" >> $GITHUB_STEP_SUMMARY
+          echo "2. **Or manually trigger** the 'Sync Documents from Google Drive' workflow" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Once synced, the story will be available for RAG queries." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Retrieval Augmented Generation (RAG) system for Ruff family documents using Go
   - [Deploy Pages](#deploy-pages)
   - [Sync Documents from Google Drive](#sync-documents-from-google-drive)
   - [Query Ruff Documents](#query-ruff-documents)
+  - [Add Story to Google Drive](#add-story-to-google-drive)
   - [Integrate Generated People](#integrate-generated-people)
   - [Edit Person Information](#edit-person-information)
   - [Generate Person Tree to Drive](#generate-person-tree-to-drive)
@@ -1087,6 +1088,42 @@ Run RAG queries directly from GitHub Actions - useful for testing or quick looku
 3. Enter: "When did the Ruff family immigrate to America?"
 4. Select model (default: gemini-2.5-flash)
 5. View answer in workflow run output
+
+### Add Story to Google Drive
+
+**File:** `add-story-to-drive.yml`
+
+**(Repo Owner Only)** Quickly add a story directly to Google Drive for RAG indexing.
+
+**Triggers:**
+- Manual only: Actions → "Add Story to Google Drive" → Run workflow
+
+**Inputs:**
+- **title** (required): Story title
+- **about** (required): Who the story is about (comma-separated names)
+- **story** (required): The story content (use `\n` for line breaks)
+- **author** (optional): Author name (default: Patrick Ruff)
+
+**Required Secrets:**
+- `GOOGLE_DRIVE_CREDENTIALS` - Service account JSON (with write access)
+
+**What it does:**
+1. Creates a Word document (.docx) with formatted story content
+2. Names it: `yyyymmdd_patstory_title.docx`
+3. Uploads to Google Drive `rufftree` folder
+4. Story becomes available for RAG after next sync
+
+**Example:**
+1. Go to Actions → "Add Story to Google Drive"
+2. Click "Run workflow"
+3. Fill in:
+   - Title: `The Christmas Cookie Tradition`
+   - About: `Debbie Ruff, Sarah Boilon`
+   - Story: `Every Christmas Eve, Debbie would bake...\n\nThe recipe had been passed down...`
+4. Run workflow
+5. Manually trigger "Sync Documents from Google Drive" (or wait 6 hours)
+
+This is the fastest way for the repo owner to add stories directly to the RAG system without creating issues.
 
 ### Integrate Generated People
 

--- a/add_story_to_drive.py
+++ b/add_story_to_drive.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Add Story to Google Drive
+
+Creates a .docx document from story text and uploads it to the rufftree
+Google Drive folder for RAG indexing.
+
+Usage:
+    python add_story_to_drive.py --title "Story Title" --about "Patrick Ruff, Jenny Wang" --story "Story content..."
+
+    Or interactively:
+    python add_story_to_drive.py --interactive
+"""
+
+import os
+import sys
+import json
+import argparse
+from datetime import datetime
+from pathlib import Path
+from io import BytesIO
+
+from docx import Document
+from docx.shared import Inches, Pt
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaIoBaseUpload
+
+
+# Configuration
+DRIVE_FOLDER_NAME = "rufftree"
+SCOPES = ['https://www.googleapis.com/auth/drive.file']  # Write access to files created by the app
+
+
+def get_drive_service():
+    """Initialize Google Drive API service with write access."""
+    creds_json = os.getenv("GOOGLE_DRIVE_CREDENTIALS")
+
+    if not creds_json:
+        raise ValueError(
+            "GOOGLE_DRIVE_CREDENTIALS environment variable not set. "
+            "This should contain your service account JSON credentials."
+        )
+
+    try:
+        creds_info = json.loads(creds_json)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in GOOGLE_DRIVE_CREDENTIALS: {e}")
+
+    credentials = service_account.Credentials.from_service_account_info(
+        creds_info,
+        scopes=SCOPES
+    )
+
+    service = build('drive', 'v3', credentials=credentials)
+    print("✅ Connected to Google Drive API")
+
+    return service
+
+
+def find_or_create_folder(service, folder_name: str) -> str:
+    """Find the rufftree folder or create it if it doesn't exist."""
+    # Search for existing folder
+    query = f"name='{folder_name}' and mimeType='application/vnd.google-apps.folder' and trashed=false"
+
+    results = service.files().list(
+        q=query,
+        spaces='drive',
+        fields='files(id, name)'
+    ).execute()
+
+    files = results.get('files', [])
+
+    if files:
+        folder_id = files[0]['id']
+        print(f"📁 Found folder: {folder_name} (ID: {folder_id})")
+        return folder_id
+
+    # Create the folder if it doesn't exist
+    file_metadata = {
+        'name': folder_name,
+        'mimeType': 'application/vnd.google-apps.folder'
+    }
+
+    folder = service.files().create(
+        body=file_metadata,
+        fields='id'
+    ).execute()
+
+    folder_id = folder.get('id')
+    print(f"📁 Created folder: {folder_name} (ID: {folder_id})")
+
+    return folder_id
+
+
+def create_story_docx(title: str, about: str, story: str, author: str = "Patrick Ruff") -> BytesIO:
+    """Create a Word document with the story content."""
+    doc = Document()
+
+    # Title
+    title_para = doc.add_heading(title, level=0)
+    title_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    # Metadata section
+    doc.add_paragraph()
+    meta_para = doc.add_paragraph()
+    meta_para.add_run(f"By: ").bold = True
+    meta_para.add_run(author)
+
+    meta_para2 = doc.add_paragraph()
+    meta_para2.add_run(f"About: ").bold = True
+    meta_para2.add_run(about)
+
+    meta_para3 = doc.add_paragraph()
+    meta_para3.add_run(f"Date: ").bold = True
+    meta_para3.add_run(datetime.now().strftime("%B %d, %Y"))
+
+    # Separator
+    doc.add_paragraph("─" * 50)
+
+    # Story content
+    doc.add_paragraph()
+    story_paragraphs = story.strip().split('\n\n')
+    for para_text in story_paragraphs:
+        if para_text.strip():
+            p = doc.add_paragraph(para_text.strip())
+            p.paragraph_format.space_after = Pt(12)
+
+    # Footer
+    doc.add_paragraph()
+    doc.add_paragraph("─" * 50)
+    footer = doc.add_paragraph()
+    footer.add_run(f"Word Count: {len(story.split())}").italic = True
+
+    # Save to BytesIO
+    docx_buffer = BytesIO()
+    doc.save(docx_buffer)
+    docx_buffer.seek(0)
+
+    return docx_buffer
+
+
+def generate_filename(title: str) -> str:
+    """Generate filename: yyyymmdd_patstory_title.docx"""
+    date_str = datetime.now().strftime("%Y%m%d")
+    # Clean title for filename
+    safe_title = "".join(c if c.isalnum() or c in ' -_' else '' for c in title)
+    safe_title = safe_title.strip().replace(' ', '_').lower()[:50]
+
+    return f"{date_str}_patstory_{safe_title}.docx"
+
+
+def upload_to_drive(service, folder_id: str, filename: str, docx_buffer: BytesIO) -> str:
+    """Upload the .docx file to Google Drive."""
+    file_metadata = {
+        'name': filename,
+        'parents': [folder_id]
+    }
+
+    media = MediaIoBaseUpload(
+        docx_buffer,
+        mimetype='application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        resumable=True
+    )
+
+    file = service.files().create(
+        body=file_metadata,
+        media_body=media,
+        fields='id, webViewLink'
+    ).execute()
+
+    file_id = file.get('id')
+    web_link = file.get('webViewLink', '')
+
+    print(f"✅ Uploaded: {filename}")
+    print(f"   File ID: {file_id}")
+    if web_link:
+        print(f"   Link: {web_link}")
+
+    return file_id
+
+
+def add_story(title: str, about: str, story: str, author: str = "Patrick Ruff"):
+    """Main function to create and upload a story to Google Drive."""
+    print("📖 Adding Story to Google Drive")
+    print("=" * 60)
+    print(f"Title: {title}")
+    print(f"About: {about}")
+    print(f"Author: {author}")
+    print(f"Word Count: {len(story.split())}")
+    print("=" * 60)
+
+    # Connect to Google Drive
+    print("\n📡 Connecting to Google Drive...")
+    service = get_drive_service()
+
+    # Find or create the rufftree folder
+    folder_id = find_or_create_folder(service, DRIVE_FOLDER_NAME)
+
+    # Create the document
+    print("\n📝 Creating Word document...")
+    docx_buffer = create_story_docx(title, about, story, author)
+
+    # Generate filename
+    filename = generate_filename(title)
+    print(f"   Filename: {filename}")
+
+    # Upload to Drive
+    print("\n📤 Uploading to Google Drive...")
+    file_id = upload_to_drive(service, folder_id, filename, docx_buffer)
+
+    print("\n" + "=" * 60)
+    print("✅ STORY ADDED SUCCESSFULLY!")
+    print("=" * 60)
+    print(f"📁 Location: Google Drive / {DRIVE_FOLDER_NAME} / {filename}")
+    print(f"🔄 The story will be indexed on the next sync (every 6 hours)")
+    print(f"   Or manually trigger: Actions → 'Sync Documents from Google Drive'")
+    print("=" * 60)
+
+    return file_id, filename
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Add a family story to Google Drive')
+    parser.add_argument('--title', '-t', help='Story title')
+    parser.add_argument('--about', '-a', help='Who the story is about (comma-separated names)')
+    parser.add_argument('--story', '-s', help='Story content')
+    parser.add_argument('--author', default='Patrick Ruff', help='Story author (default: Patrick Ruff)')
+    parser.add_argument('--interactive', '-i', action='store_true', help='Interactive mode')
+
+    args = parser.parse_args()
+
+    if args.interactive:
+        print("📖 Add Family Story to Google Drive")
+        print("=" * 60)
+        title = input("\nStory Title: ").strip()
+        about = input("Who is this story about? (comma-separated): ").strip()
+        author = input("Your name (press Enter for 'Patrick Ruff'): ").strip() or "Patrick Ruff"
+        print("\nEnter your story (end with an empty line):")
+        lines = []
+        while True:
+            try:
+                line = input()
+                if line == "":
+                    if lines and lines[-1] == "":
+                        break  # Two empty lines = done
+                    lines.append(line)
+                else:
+                    lines.append(line)
+            except EOFError:
+                break
+        story = "\n".join(lines).strip()
+    else:
+        # Check required args
+        if not args.title or not args.about or not args.story:
+            parser.error("--title, --about, and --story are required (or use --interactive)")
+
+        title = args.title
+        about = args.about
+        story = args.story
+        author = args.author
+
+    if not title or not about or not story:
+        print("❌ Error: Title, about, and story content are required")
+        sys.exit(1)
+
+    try:
+        add_story(title, about, story, author)
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/submit_story.html
+++ b/submit_story.html
@@ -659,7 +659,7 @@ ${JSON.stringify({
 *A maintainer will review and add it to the family archive.*`
             );
 
-            const issueUrl = `https://github.com/${GITHUB_REPO}/issues/new?title=${title}&body=${body}&labels=family-story`;
+            const issueUrl = `https://github.com/${GITHUB_REPO}/issues/new?title=${title}&body=${body}&labels=family-story,story:pending`;
             window.open(issueUrl, '_blank');
 
             document.getElementById('successMessage').style.display = 'block';


### PR DESCRIPTION
- Create add_story_to_drive.py script to create .docx files and upload to Google Drive with naming convention: yyyymmdd_patstory_title.docx
- Add add-story-to-drive.yml workflow for repo owner to quickly add stories directly to Google Drive without creating issues
- Update submit_story.html to include story:pending label
- Update README with new workflow documentation

This allows the repo owner to bypass the issue workflow and add stories directly to the RAG system by running a simple GitHub Action.