### PR TITLE
Fix story submission workflow not triggering

### DIFF
--- a/.github/workflows/process-story-issue.yml
+++ b/.github/workflows/process-story-issue.yml
@@ -2,12 +2,12 @@ name: Process Family Story Issue
 
 on:
   issues:
-    types: [opened]
+    types: [labeled]
 
 jobs:
   process-story:
-    # Only run for issues with 'family-story' label (auto-applied by template)
-    if: contains(github.event.issue.labels.*.name, 'family-story')
+    # Only run when the 'family-story' label is added
+    if: github.event.label.name == 'family-story'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Changed process-story-issue.yml to trigger on 'labeled' event instead of 'opened'. This ensures the workflow runs after auto-label-issues.yml adds the family-story label, fixing the issue where stories submitted via the website weren't being processed.

Before: workflow checked for label on 'opened' event, but label didn't exist yet
After: workflow triggers when 'family-story' label is added, guaranteeing the label exists