### PR TITLE
Add spouse option for married person

### DIFF
--- a/easy_add.html
+++ b/easy_add.html
@@ -364,6 +364,17 @@
                 </div>
 
                 <div class="relationship-group">
+                    <h3>💍 Spouse <span class="optional">(optional)</span></h3>
+                    <div class="form-group">
+                        <div class="autocomplete-container">
+                            <input type="text" id="spouseInput" placeholder="Type to search for spouse..." autocomplete="off">
+                            <div class="autocomplete-list" id="spouseList"></div>
+                        </div>
+                        <div class="selected-people" id="selectedSpouse"></div>
+                    </div>
+                </div>
+
+                <div class="relationship-group">
                     <h3>👶 Children <span class="optional">(optional)</span></h3>
                     <div class="form-group">
                         <div class="autocomplete-container">
@@ -385,6 +396,7 @@
     <script>
         let familyData = null;
         let selectedParents = [];
+        let selectedSpouse = null;
         let selectedChildren = [];
 
         // Load family tree data
@@ -448,6 +460,75 @@
             });
         }
 
+        // Autocomplete for spouse (single selection)
+        function setupSpouseAutocomplete() {
+            const input = document.getElementById('spouseInput');
+            const list = document.getElementById('spouseList');
+
+            input.addEventListener('input', function() {
+                const searchTerm = this.value.toLowerCase().trim();
+                list.innerHTML = '';
+
+                if (!searchTerm || !familyData) {
+                    list.classList.remove('active');
+                    return;
+                }
+
+                const matches = Object.values(familyData)
+                    .filter(person => {
+                        const fullName = person.name.toLowerCase();
+                        const alreadySelected = selectedSpouse && selectedSpouse.id === person.id;
+                        return fullName.includes(searchTerm) && !alreadySelected;
+                    })
+                    .slice(0, 10);
+
+                if (matches.length > 0) {
+                    matches.forEach(person => {
+                        const item = document.createElement('div');
+                        item.className = 'autocomplete-item';
+                        item.textContent = `${person.name} ${person.dob && person.dob !== 'unknown' ? `(b. ${person.dob})` : ''}`;
+                        item.addEventListener('click', () => {
+                            selectedSpouse = person;
+                            renderSelectedSpouse();
+                            input.value = '';
+                            list.classList.remove('active');
+                        });
+                        list.appendChild(item);
+                    });
+                    list.classList.add('active');
+                } else {
+                    list.classList.remove('active');
+                }
+            });
+
+            // Close autocomplete when clicking outside
+            document.addEventListener('click', function(e) {
+                if (!input.contains(e.target) && !list.contains(e.target)) {
+                    list.classList.remove('active');
+                }
+            });
+        }
+
+        function renderSelectedSpouse() {
+            const container = document.getElementById('selectedSpouse');
+            container.innerHTML = '';
+
+            if (selectedSpouse) {
+                const tag = document.createElement('div');
+                tag.className = 'person-tag';
+                tag.innerHTML = `
+                    <span>${selectedSpouse.name}</span>
+                    <button type="button" onclick="removeSpouse()">×</button>
+                `;
+                container.appendChild(tag);
+            }
+        }
+
+        function removeSpouse() {
+            selectedSpouse = null;
+            renderSelectedSpouse();
+        }
+
         function addSelectedPerson(person, selectedArray, containerId) {
             if (!selectedArray.some(p => p.id === person.id)) {
                 selectedArray.push(person);
@@ -499,8 +580,10 @@
         function resetForm() {
             document.getElementById('easyAddForm').reset();
             selectedParents = [];
+            selectedSpouse = null;
             selectedChildren = [];
             renderSelectedPeople(selectedParents, 'selectedParents');
+            renderSelectedSpouse();
             renderSelectedPeople(selectedChildren, 'selectedChildren');
         }
 
@@ -532,7 +615,7 @@
                 parentIds: selectedParents.map(p => p.id),
                 childrenIds: selectedChildren.map(p => p.id),
                 siblingIds: [],
-                spouseId: null
+                spouseId: selectedSpouse ? selectedSpouse.id : null
             };
 
             // Create JSON blob and download
@@ -554,10 +637,12 @@
         // Initialize
         loadFamilyData();
         setupAutocomplete('parentInput', 'parentList', selectedParents, 'selectedParents');
+        setupSpouseAutocomplete();
         setupAutocomplete('childInput', 'childList', selectedChildren, 'selectedChildren');
 
         // Make functions globally accessible for onclick handlers
         window.removeSelectedPerson = removeSelectedPerson;
+        window.removeSpouse = removeSpouse;
         window.resetForm = resetForm;
         window.findPersonById = findPersonById;
     </script>

--- a/person_generator.html
+++ b/person_generator.html
@@ -747,6 +747,16 @@
                 </div>
 
                 <div class="form-group full-width">
+                    <label for="spouse">Spouse (married to)</label>
+                    <select id="spouse">
+                        <option value="">-- Select Spouse --</option>
+                    </select>
+                    <div style="margin-top: 5px; font-size: 12px; color: #666;">
+                        Select the person this individual is married to.
+                    </div>
+                </div>
+
+                <div class="form-group full-width">
                     <label for="addAsChildOf">Add as Child of (existing person)</label>
                     <select id="addAsChildOf">
                         <option value="">-- Not adding as child --</option>
@@ -888,6 +898,7 @@
             const people = familyTreeData.family.people;
             const parent1Select = document.getElementById('parent1');
             const parent2Select = document.getElementById('parent2');
+            const spouseSelect = document.getElementById('spouse');
             const addAsChildSelect = document.getElementById('addAsChildOf');
 
             // Sort people by name for easier selection
@@ -898,6 +909,7 @@
             // Clear existing options (except the first default option)
             parent1Select.innerHTML = '<option value="">-- Select Parent 1 --</option>';
             parent2Select.innerHTML = '<option value="">-- Select Parent 2 --</option>';
+            spouseSelect.innerHTML = '<option value="">-- Select Spouse --</option>';
             addAsChildSelect.innerHTML = '<option value="">-- Not adding as child --</option>';
 
             sortedPeople.forEach(person => {
@@ -916,6 +928,12 @@
                 parent2Option.value = person.id;
                 parent2Option.textContent = optionText;
                 parent2Select.appendChild(parent2Option);
+
+                // Add to spouse dropdown
+                const spouseOption = document.createElement('option');
+                spouseOption.value = person.id;
+                spouseOption.textContent = optionText;
+                spouseSelect.appendChild(spouseOption);
 
                 // Add to "add as child of" dropdown
                 const childOption = document.createElement('option');
@@ -1406,8 +1424,11 @@ ${jsonString}
             // Get "add as child of" selection
             const addAsChildOf = document.getElementById('addAsChildOf').value;
 
+            // Get spouse selection
+            const spouseId = document.getElementById('spouse').value;
+
             // Set up relationships
-            person.spouseId = null;
+            person.spouseId = spouseId || null;
             person.parentIds = parentIds;
             person.siblingIds = [];
             person.childrenIds = [];


### PR DESCRIPTION
Added spouse/married_to relationship option to both easy add and person generator forms:

- easy_add.html: Added spouse autocomplete field with single-person selection
- person_generator.html: Added spouse dropdown to relationship section
- Both forms now properly populate spouseId field when a spouse is selected

This allows users to set the married_to relationship when creating new family members.