### PR TITLE
Fix generation hierarchy and tree orientation

### DIFF
--- a/graph.html
+++ b/graph.html
@@ -278,11 +278,11 @@
                     <h4>Generations</h4>
                     <div class="legend-item">
                         <div style="width: 20px; height: 20px; background: #8B4513; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
-                        <span>Great-grandparents (-2)</span>
+                        <span>Grandparents (-2)</span>
                     </div>
                     <div class="legend-item">
                         <div style="width: 20px; height: 20px; background: #FF6B6B; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
-                        <span>Grandparents (-1)</span>
+                        <span>Parents (-1)</span>
                     </div>
                     <div class="legend-item">
                         <div style="width: 20px; height: 20px; background: #4ECDC4; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
@@ -341,8 +341,8 @@
         // Generation color mapping
         function getGenerationColor(fromPat) {
             const colors = {
-                '-2': '#8B4513',  // Great-grandparents - Brown
-                '-1': '#FF6B6B',  // Grandparents - Red
+                '-2': '#8B4513',  // Grandparents - Brown
+                '-1': '#FF6B6B',  // Parents - Red
                 '0': '#4ECDC4',   // Pat's generation - Teal
                 '1': '#95E1D3',   // Children - Light green
                 '2': '#FFE66D',   // Grandchildren - Yellow
@@ -367,7 +367,7 @@
                     title: `${person.name}\n${person.generation || 'Unknown'}\n${age}${isAlive ? ' years old' : ''}`,
                     shape: 'dot',
                     size: 25,
-                    level: -fromPat, // Negative because higher generations should be at top (lower Y values)
+                    level: fromPat, // Positive fromPat = lower levels (grandparents at top with negative fromPat)
                     color: {
                         background: nodeColor,
                         border: '#333',


### PR DESCRIPTION
- Correct generation labels: Grandparents (-2), Parents (-1), not great-grandparents
- Fix tree orientation: change level from -fromPat to fromPat
- Now grandparents display at top, children at bottom (proper tree flow)