### PR TITLE
Fix graph colors and legend to be more distinct and accurate

### DIFF
--- a/graph.html
+++ b/graph.html
@@ -276,29 +276,33 @@
                 <div class="person-info" id="personInfo"></div>
 
                 <div class="legend">
-                    <h4>Generations</h4>
+                    <h4>Generations (Oldest → Youngest)</h4>
                     <div class="legend-item">
-                        <div style="width: 20px; height: 20px; background: #8B4513; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <div style="width: 20px; height: 20px; background: #4A148C; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <span>Greatest Generation (-3)</span>
+                    </div>
+                    <div class="legend-item">
+                        <div style="width: 20px; height: 20px; background: #D84315; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
                         <span>Silent Generation (-2)</span>
                     </div>
                     <div class="legend-item">
-                        <div style="width: 20px; height: 20px; background: #FF6B6B; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <div style="width: 20px; height: 20px; background: #1976D2; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
                         <span>Baby Boomers (-1)</span>
                     </div>
                     <div class="legend-item">
-                        <div style="width: 20px; height: 20px; background: #4ECDC4; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <div style="width: 20px; height: 20px; background: #388E3C; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
                         <span>Gen X / Millennials (0)</span>
                     </div>
                     <div class="legend-item">
-                        <div style="width: 20px; height: 20px; background: #95E1D3; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <div style="width: 20px; height: 20px; background: #F57C00; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
                         <span>Gen Z (+1)</span>
                     </div>
                     <div class="legend-item">
-                        <div style="width: 20px; height: 20px; background: #FFE66D; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <div style="width: 20px; height: 20px; background: #C2185B; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
                         <span>Gen Alpha (+2)</span>
                     </div>
                     <div class="legend-item">
-                        <div style="width: 20px; height: 20px; background: #C7CEEA; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
+                        <div style="width: 20px; height: 20px; background: #FBC02D; border-radius: 50%; margin-right: 10px; border: 2px solid #333;"></div>
                         <span>Gen Beta (+3)</span>
                     </div>
 
@@ -342,19 +346,21 @@
         // Generation color mapping
         function getGenerationColor(fromPat) {
             const colors = {
-                '-2': '#8B4513',  // Silent Generation - Brown
-                '-1': '#FF6B6B',  // Baby Boomers - Red
-                '0': '#4ECDC4',   // Gen X / Millennials - Teal
-                '1': '#95E1D3',   // Gen Z - Light green
-                '2': '#FFE66D',   // Gen Alpha - Yellow
-                '3': '#C7CEEA'    // Gen Beta - Light purple
+                '-3': '#4A148C',  // Greatest Generation - Deep Purple
+                '-2': '#D84315',  // Silent Generation - Deep Orange
+                '-1': '#1976D2',  // Baby Boomers - Bright Blue
+                '0': '#388E3C',   // Gen X / Millennials - Green
+                '1': '#F57C00',   // Gen Z - Orange
+                '2': '#C2185B',   // Gen Alpha - Pink
+                '3': '#FBC02D'    // Gen Beta - Yellow
             };
-            return colors[fromPat.toString()] || '#B8B8B8'; // Default gray
+            return colors[fromPat.toString()] || '#757575'; // Default gray for unknown
         }
 
         // Get generation name based on from_pat
         function getGenerationName(fromPat) {
             const names = {
+                '-3': 'Greatest Generation',
                 '-2': 'Silent Generation',
                 '-1': 'Baby Boomers',
                 '0': 'Gen X / Millennials',


### PR DESCRIPTION
- Add support for Greatest Generation (-3) which was showing as gray
- Use much more visually distinct colors:
  * Deep Purple for Greatest Generation
  * Deep Orange for Silent Generation
  * Bright Blue for Baby Boomers
  * Green for Gen X/Millennials
  * Orange for Gen Z
  * Pink for Gen Alpha
  * Yellow for Gen Beta
- Update legend to show all generations including -3
- Match legend colors exactly to graph node colors
- Clarify legend header: "Generations (Oldest → Youngest)"