### PR TITLE
Fix story workflow to prevent triple processing

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -22,18 +22,9 @@ jobs:
 
             // Check if this is a story issue
             if (issueTitle.startsWith('[Story]')) {
-              console.log('Detected story issue - adding labels');
+              console.log('Detected story issue - adding comment (labels already set by template)');
 
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                labels: ['family-story', 'story:pending']
-              });
-
-              console.log('✅ Added labels: family-story, story:pending');
-
-              // Add a comment to inform the user
+              // Labels are already added by the issue template, just add an informative comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/process-story-issue.yml
+++ b/.github/workflows/process-story-issue.yml
@@ -1,18 +1,17 @@
 name: Process Family Story Issue
 
 on:
-  # Run every 20 minutes to check for new story issues
-  schedule:
-    - cron: '*/20 * * * *'
-  # Allow manual triggering
+  # Allow manual triggering for reprocessing
   workflow_dispatch:
-  # Also try to trigger on issue events
+  # Trigger only when issue is opened (not labeled, to avoid duplicates)
   issues:
-    types: [labeled, opened]
+    types: [opened]
 
 jobs:
   process-story:
     runs-on: ubuntu-latest
+    # Only process if issue has story:pending label (not already processed)
+    if: contains(github.event.issue.labels.*.name, 'story:pending')
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Previously stories were added to RAG 3 times due to multiple triggers:
- Removed schedule cron trigger (was re-processing every 20 min)
- Removed 'labeled' event trigger (was re-processing on label add)
- Added safety check to only process stories with 'story:pending' label
- Removed redundant label addition in auto-label workflow

Stories will now be processed exactly once when the issue is opened.